### PR TITLE
Vulkan: Reset queries on same command buffer (#4329)

### DIFF
--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Vulkan
         protected readonly Device Device;
         public readonly PipelineCache PipelineCache;
 
-        protected readonly AutoFlushCounter AutoFlush;
+        public readonly AutoFlushCounter AutoFlush;
 
         protected PipelineDynamicState DynamicState;
         private PipelineState _newState;

--- a/Ryujinx.Graphics.Vulkan/Queries/CounterQueueEvent.cs
+++ b/Ryujinx.Graphics.Vulkan/Queries/CounterQueueEvent.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.Graphics.Vulkan.Queries
 
             DrawIndex = drawIndex;
 
-            _counter.Begin();
+            _counter.Begin(_queue.ResetSequence);
         }
 
         public Auto<DisposableBuffer> GetBuffer()

--- a/Ryujinx.Graphics.Vulkan/Queries/Counters.cs
+++ b/Ryujinx.Graphics.Vulkan/Queries/Counters.cs
@@ -24,6 +24,19 @@ namespace Ryujinx.Graphics.Vulkan.Queries
             }
         }
 
+        public void ResetCounterPool()
+        {
+            foreach (var queue in _counterQueues)
+            {
+                queue.ResetCounterPool();
+            }
+        }
+
+        public void ResetFutureCounters(CommandBuffer cmd, int count)
+        {
+            _counterQueues[(int)CounterType.SamplesPassed].ResetFutureCounters(cmd, count);
+        }
+
         public CounterQueueEvent QueueReport(CounterType type, EventHandler<ulong> resultHandler, bool hostReserved)
         {
             return _counterQueues[(int)type].QueueReport(resultHandler, _pipeline.DrawCount, hostReserved);

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -679,6 +679,16 @@ namespace Ryujinx.Graphics.Vulkan
             _counters.Update();
         }
 
+        public void ResetCounterPool()
+        {
+            _counters.ResetCounterPool();
+        }
+
+        public void ResetFutureCounters(CommandBuffer cmd, int count)
+        {
+            _counters?.ResetFutureCounters(cmd, count);
+        }
+
         public void BackgroundContextAction(Action action, bool alwaysBackground = false)
         {
             action();

--- a/Ryujinx.Graphics.Vulkan/Window.cs
+++ b/Ryujinx.Graphics.Vulkan/Window.cs
@@ -225,6 +225,8 @@ namespace Ryujinx.Graphics.Vulkan
 
         public unsafe override void Present(ITexture texture, ImageCrop crop, Action swapBuffersCallback)
         {
+            _gd.PipelineInternal.AutoFlush.Present();
+
             uint nextImage = 0;
 
             while (true)


### PR DESCRIPTION
* Reset queries on same command buffer

Vulkan seems to complain when the queries are reset on another command buffer. No idea why, the spec really could be written better in this regard. This fixes complaints, and hopefully any implementations that care extensively about them.

This change _guesses_ how many queries need to be reset and resets as many as possible at the same time to avoid splitting render passes. If it resets too many queries, we didn't waste too much time - if it runs out of resets it will batch reset 10 more.

The number of queries reset is the maximum number of queries in the last 3 frames. This has been worked into the AutoFlushCounter so that it only resets up to 32 if it is yet to force a command buffer submission in this attachment.

This is only done for samples passed queries right now, as they have by far the most resets.

* Address Feedback